### PR TITLE
fix: pin gosec and gotestsum to Go 1.23 compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: go mod download
 
       - name: Install gotestsum for test reporting
-        run: go install gotest.tools/gotestsum@latest
+        run: go install gotest.tools/gotestsum@v1.12.0
 
       - name: Run unit tests
         run: |
@@ -190,7 +190,7 @@ jobs:
 
       - name: Install and run gosec
         run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.22.0
           gosec -fmt sarif -out gosec.sarif -severity medium ./...
 
       - name: Run govulncheck

--- a/.github/workflows/pr-feedback.yml
+++ b/.github/workflows/pr-feedback.yml
@@ -77,8 +77,8 @@ jobs:
       # Run comprehensive tests
       - name: Install test tools
         run: |
-          go install gotest.tools/gotestsum@latest
-          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          go install gotest.tools/gotestsum@v1.12.0
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.22.0
           go install golang.org/x/vuln/cmd/govulncheck@latest
 
       - name: Run unit tests with coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Run security scan
         run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.22.0
           gosec ./...
 
   # Create release


### PR DESCRIPTION
## Problem

CI pipeline is failing because recent releases of gosec and gotestsum require Go 1.24, which doesn't exist yet (latest stable is Go 1.23).

**Error messages:**
```
gosec: requires go >= 1.24.0 (running go 1.23.12; GOTOOLCHAIN=local)
gotestsum: requires go >= 1.24.0 (running go 1.23.12; GOTOOLCHAIN=local)
```

## Solution

Pin both tools to their last Go 1.23 compatible versions:
- **gosec**: `@v2.22.0` (instead of `@latest`)
- **gotestsum**: `@v1.12.0` (instead of `@latest`)

## Changes

```yaml
# Before
go install gotest.tools/gotestsum@latest
go install github.com/securego/gosec/v2/cmd/gosec@latest

# After  
go install gotest.tools/gotestsum@v1.12.0
go install github.com/securego/gosec/v2/cmd/gosec@v2.22.0
```

## Testing

Once merged, CI pipeline should:
- ✅ Security job: gosec installs and runs successfully
- ✅ Test job: gotestsum installs and generates test report
- ✅ Test report: tests.xml file is created and uploaded

## Impact

- No functional changes to security scanning or testing
- Same coverage and linting standards maintained
- Pipeline stability restored until Go 1.24 is released