### PR TITLE
feat: improve hero background with fixed attachment and fallback color

### DIFF
--- a/docs/assets/scss/_styles_project.scss
+++ b/docs/assets/scss/_styles_project.scss
@@ -54,7 +54,8 @@ body, .td-content {
   background-position: center center !important;
   background-size: cover !important;
   background-repeat: no-repeat !important;
-  background-color: transparent !important;
+  background-color: #0f172a !important;
+  background-attachment: fixed !important;
   position: relative;
 
   &::after {


### PR DESCRIPTION
## Changes
- Added `background-attachment: fixed` for parallax scrolling effect
- Added `background-color: #0f172a` as fallback color while image loads

## Testing
- Verified locally with Hugo server
- Tested both local and GitHub Pages deployment compatibility

## Related
Part of documentation improvements to ensure consistent display across environments.