### PR TITLE
fix: hero button spacing using flexbox gap

### DIFF
--- a/docs/assets/scss/_styles_project.scss
+++ b/docs/assets/scss/_styles_project.scss
@@ -706,11 +706,12 @@ pre {
     }
 
     .hero-actions {
+      gap: 0.75rem !important;
+
       .btn {
         display: block;
         width: 100%;
-        margin-bottom: 0.75rem;
-        margin-right: 0 !important;
+        margin-bottom: 0;
 
         &:last-child {
           margin-bottom: 0;

--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -15,12 +15,12 @@ title = "MCP Shell"
           Cross-platform. Security-first. Ready for production.
         </p>
 
-        <div class="hero-actions mt-4">
-          <a class="btn btn-lg btn-primary mr-4 mb-3" href="{{< relref "/docs/installation" >}}">
+        <div class="hero-actions mt-4 d-flex flex-wrap gap-3">
+          <a class="btn btn-lg btn-primary mb-3" href="{{< relref "/docs/installation" >}}">
             <i class="fas fa-rocket mr-2"></i>
             Install Now
           </a>
-          <a class="btn btn-lg btn-outline-light mr-4 mb-3" href="https://github.com/rafa-dot-el/mcp-shell">
+          <a class="btn btn-lg btn-outline-light mb-3" href="https://github.com/rafa-dot-el/mcp-shell">
             <i class="fab fa-github mr-2"></i>
             Source
           </a>


### PR DESCRIPTION
## Problem
Hero buttons ("Install Now" and "Source") had no spacing between them on GitHub Pages, despite having `mr-4` class. The issue was caused by CSS specificity problems with margin overrides.

## Solution
- Changed HTML to use `d-flex flex-wrap gap-3` on `.hero-actions` container
- Removed `mr-4` from individual buttons (no longer needed)
- Updated mobile responsive CSS to use `gap` instead of `margin-right: 0 !important`

## Result
- **Desktop**: 12px gap between buttons (via `gap-3`)
- **Mobile**: 0.75rem gap between stacked buttons
- Consistent spacing across local and deployed environments

## Testing
- All CI checks passing on dev branch
- Verified on local Hugo server